### PR TITLE
devnet: config-node and config-wallet babbage compatible

### DIFF
--- a/config/devnet/perun-pab.yaml
+++ b/config/devnet/perun-pab.yaml
@@ -10,6 +10,7 @@ pabWebserverConfig:
   # available. If this is not set, calls to unavailable endpoints fail
   # immediately.
   endpointTimeout: 5
+  enableMarconi: False
 
 walletServerConfig:
   tag: LocalWalletConfig

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:latest
+    image: inputoutput/cardano-node:1.35.3
     ports:
       - "3001:3001"
     volumes:
@@ -26,7 +26,7 @@ services:
       ]
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:latest
+    image: inputoutput/cardano-wallet:2022.8.16
     volumes:
       - ./wallet-db:/wallet-db
       - ./devnet:/data


### PR DESCRIPTION
We want our devnet to be babbage compatible. This is done by fixing cardano-node@1.35.3 and cardano-wallet@2022-08-16.

Tested with plutus-apps@e25565ae8bd8a5b06b095e8fdeec90ce1ba65773 of the next-node branch.